### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/RolfKoenders/potato.svg?branch=master)](https://travis-ci.org/RolfKoenders/potato)
 [![Beerpay](https://beerpay.io/RolfKoenders/potato/badge.svg?style=flat)](https://beerpay.io/RolfKoenders/potato)
 [![Docker Pulls](https://img.shields.io/docker/pulls/rolfkoenders/potato.svg)](https://hub.docker.com/r/rolfkoenders/potato/)
-[![Docker Automated buil](https://img.shields.io/docker/automated/rolfkoenders/potato.svg)](https://hub.docker.com/r/rolfkoenders/potato/)
+[![Docker Automated buil](https://img.shields.io/docker/automated/rolfkoenders/potato.svg)](https://hub.docker.com/r/rolfkoenders/potato/) [![](https://images.microbadger.com/badges/image/rolfkoenders/potato.svg)](https://microbadger.com/images/rolfkoenders/potato "Get your own image badge on microbadger.com")
 
 > Add movies to your couchpotato wanted list with just a simple slack message!
 
@@ -93,3 +93,4 @@ You can update couchpotato by sending the `!update` command. _Check with `!versi
 
 ### License
 [MIT](https://opensource.org/licenses/MIT)
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [rolfkoenders/potato](https://hub.docker.com/r/rolfkoenders/potato/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/rolfkoenders/potato).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/rolfkoenders/potato.svg)](https://microbadger.com/images/rolfkoenders/potato)
